### PR TITLE
Fix tracemadness entrypoint's path to its temporary ghidra server's "repositories" directory to match that expected by ghidra 11.3.1

### DIFF
--- a/container-tracemadness/entrypoint.py
+++ b/container-tracemadness/entrypoint.py
@@ -78,7 +78,7 @@ class TemporaryGhidraServer(object):
         ghidra_server_conf = ghidra_install_dir() / "server" / "server.conf"
         restore_conf = False
         self.tmpdir = TempDir()
-        repos = self.tmpdir.path / "repos"
+        repos = self.tmpdir.path / "repositories"
         try:
             repos.mkdir()
             shutil.copy2(str(ghidra_server_conf), str(self.tmpdir.path / "server.conf"))


### PR DESCRIPTION
The default repositories path in ghidra 11.3.1 is now specified differently; update the tracemadness entrypoint to match