### PR TITLE
fix: count tm-index ticks on instruction records

### DIFF
--- a/dynamic-trace/src/bin/tm-index.rs
+++ b/dynamic-trace/src/bin/tm-index.rs
@@ -63,7 +63,7 @@ fn parse_ops(args: Args) -> Result<(Vec<Operation>, u64)> {
         .for_each(|raw| {
             match arch.parse_record(raw) {
                 Err(_) => eprintln!("Error encountered during parsing"),
-                Ok(Record::Pc(_)) => tick += 1,
+                Ok(Record::Instruction(_)) => tick += 1,
                 Ok(Record::MemRead(read)) => ops.push(Operation {
                     space: SpaceKind::Memory,
                     data: read.contents().to_vec(),


### PR DESCRIPTION
## Summary
- advance `tm-index` ticks when an `Instruction` record is parsed instead of when a `Pc` record is parsed
- keeps the first instruction at tick 0 and avoids shifting indexed operation times forward by one

## Why
`tm-index` initializes `tick` to 0, but previously incremented it on `Record::Pc`. That means the first instruction's memory/register operations are indexed at tick 1. Other trace analysis code treats `Record::Instruction` as the instruction boundary, so this aligns index generation with the instruction stream.

Closes #14

## Validation
- `cargo fmt -p trace --check`
- `git diff --check`

I also tried `cargo check -p trace --features dynamic-trace-bin --bin tm-index`, but the build is blocked before checking this binary by `ghidra-lifter`'s build script failing while running `bison` on vendored parser grammars (`xml.y`, `grammar.y`, `pcodeparse.y`).
